### PR TITLE
Set Icon parent to text frame to respect selected strata levels

### DIFF
--- a/NameplateSCT.lua
+++ b/NameplateSCT.lua
@@ -282,6 +282,7 @@ local MISS_EVENT_STRINGS = {
       if NameplateSCT.db.global.showIcon then
         if not fontString.icon then
           fontString.icon = NameplateSCT.frame:CreateTexture(nil, "BACKGROUND");
+          fontString.icon:SetParent(fontStringFrame);
         end
         fontString.icon:SetAlpha(1);
         fontString.icon:SetTexture("Interface\\Icons\\INV_Misc_QuestionMark")


### PR DESCRIPTION
I believe the icon should use the Target or Off-Target Strata levels selected in Appearance/Offsets. This change allows the icon to inherit that property.