### PR TITLE
Update interface version

### DIFF
--- a/NameplateSCT.toc
+++ b/NameplateSCT.toc
@@ -1,4 +1,4 @@
-## Interface: 100002
+## Interface: 100000
 ## Version: 1.28
 ## Title: NameplateSCT
 ## Author: mpstark, Justwait


### PR DESCRIPTION
`100002` is not recognized by the WoW client as a valid interface version, and falsely reports the addon as out of date.

![WoWScrnShot_102722_233215](https://user-images.githubusercontent.com/9218035/198497701-effb126b-e1d5-4d00-bbd6-bb0dcc4146a8.jpg)
