### PR TITLE
Update NameplateSCT.lua

### DIFF
--- a/Locales/enUS.lua
+++ b/Locales/enUS.lua
@@ -47,7 +47,6 @@ L["Parried"] = true
 L["Reflected"] = true
 L["Resisted"] = true
 L[" Overkill("] = true
-L["Missed"] = true
 
 -- Options
 L["NPCs"] = true

--- a/Locales/enUS.lua
+++ b/Locales/enUS.lua
@@ -46,6 +46,8 @@ L["Missed"] = true
 L["Parried"] = true
 L["Reflected"] = true
 L["Resisted"] = true
+L[" Overkill("] = true
+L["Missed"] = true
 
 -- Options
 L["NPCs"] = true

--- a/NameplateSCT.lua
+++ b/NameplateSCT.lua
@@ -851,7 +851,7 @@ function NameplateSCT:DamageEvent(guid, spellName, amount, overkill, school, cri
 	end
 
 	if (overkill > 0 and self.db.global.shouldDisplayOverkill) then
-		text = self:ColorText(text.." Overkill("..overkill..")", guid, playerGUID, school, spellName);
+		text = self:ColorText(text..L[" Overkill("]..overkill..")", guid, playerGUID, school, spellName);
 		self:DisplayTextOverkill(guid, text, size, animation, spellId, pow, spellName);
 	else
 		self:DisplayText(guid, text, size, animation, spellId, pow, spellName);
@@ -891,7 +891,7 @@ function NameplateSCT:MissEvent(guid, spellName, missType, spellId)
 
 	pow = true;
 
-	text = MISS_EVENT_STRINGS[missType] or "Missed";
+	text = MISS_EVENT_STRINGS[missType] or L["Missed"];
 	text = "|Cff"..color..text.."|r";
 
 	self:DisplayText(guid, text, size, animation, spellId, pow, spellName)


### PR DESCRIPTION
thanks
L["Display Overkill"] = "显示击杀"
L["Display your overkill for a target over your own nameplate"] = "在个人资源条上显示你对目标的最后一击"
L["Filters"] = "过滤器"
L["Spells"] = "技能"
L[" Overkill("] = "击杀(过量:"
L["NPCs"] = "NPC"
L["NPC id (eg: 23682) seperated by line\n\n The example is the Headless Horseman."] = "NPC ID (例如: 23682) 以行分割\n\n 例如：无头骑士。"