### PR TITLE
Add a toggle to disable off-target text and number truncation improvement

### DIFF
--- a/Locales/enUS.lua
+++ b/Locales/enUS.lua
@@ -104,6 +104,7 @@ L["Show Truncated Letter"] = true
 L["Comma Seperate"] = true
 L["Size"] = true
 L["Alpha"] = true
+L["Display Off-Target Text"] = true
 L["Use Seperate Off-Target Text Appearance"] = true
 L["Off-Target Text Appearance"] = true
 L["Sizing Modifiers"] = true

--- a/Locales/enUS.lua
+++ b/Locales/enUS.lua
@@ -100,6 +100,11 @@ L["Y Offset Personal SCT"] = true
 L["Only used if Personal Nameplate is Disabled"] = true
 L["Text Formatting"] = true
 L["Truncate Number"] = true
+L["Truncate Method:\n\nWestern:\n  1000=>1K,\n  1000K=>1M\nAsia East:\n  10000=>1w"] = true
+L["Truncate Letter East Asia"] = true
+L['Do Not Truncate'] = true
+L['Western'] = true
+L['East Asia'] = true
 L["Show Truncated Letter"] = true
 L["Comma Seperate"] = true
 L["Size"] = true

--- a/NameplateSCT.lua
+++ b/NameplateSCT.lua
@@ -160,7 +160,8 @@ local defaults = {
 			alpha = 1,
 		},
 
-		useOffTarget = true,
+		useOffTargetAppearance = true,
+		displayOffTargetText = true,
 		offTargetFormatting = {
 			size = 15,
 			alpha = 0.5,
@@ -548,7 +549,7 @@ local function AnimationOnUpdate()
 
 				-- alpha
 				local startAlpha = NameplateSCT.db.global.formatting.alpha;
-				if (NameplateSCT.db.global.useOffTarget and not isTarget and fontString.unit ~= "player") then
+				if (NameplateSCT.db.global.useOffTargetAppearance and not isTarget and fontString.unit ~= "player") then
 					startAlpha = NameplateSCT.db.global.offTargetFormatting.alpha;
 				end
 
@@ -815,7 +816,11 @@ function NameplateSCT:DamageEvent(guid, spellName, amount, overkill, school, cri
 	local unit = guidToUnit[guid];
 	local isTarget = unit and UnitIsUnit(unit, "target");
 
-	if (self.db.global.useOffTarget and not isTarget and playerGUID ~= guid) then
+	if (not isTarget and not self.db.global.displayOffTargetText) then
+		return;
+	end
+
+	if (self.db.global.useOffTargetAppearance and not isTarget and playerGUID ~= guid) then
 		size = self.db.global.offTargetFormatting.size;
 		alpha = self.db.global.offTargetFormatting.alpha;
 	else
@@ -912,7 +917,7 @@ function NameplateSCT:MissEvent(guid, spellName, missType, spellId)
 	return;
 	end;
 
-	if (self.db.global.useOffTarget and not isTarget and playerGUID ~= guid) then
+	if (self.db.global.useOffTargetAppearance and not isTarget and playerGUID ~= guid) then
 		size = self.db.global.offTargetFormatting.size;
 		alpha = self.db.global.offTargetFormatting.alpha;
 	else
@@ -1596,19 +1601,30 @@ local menu = {
 					order = 53,
 				},
 
-				useOffTarget = {
+				displayOffTargetText = {
+					type = 'toggle',
+					name = L['Display Off-Target Text'],
+					desc = "",
+					get = function() return NameplateSCT.db.global.displayOffTargetText; end,
+					set = function(_, newValue) NameplateSCT.db.global.displayOffTargetText = newValue; end,
+					order = 99,
+					width = "full",
+				},
+
+				useOffTargetAppearance = {
 					type = 'toggle',
 					name = L["Use Seperate Off-Target Text Appearance"],
 					desc = "",
-					get = function() return NameplateSCT.db.global.useOffTarget; end,
-					set = function(_, newValue) NameplateSCT.db.global.useOffTarget = newValue; end,
+					disabled = function() return not NameplateSCT.db.global.displayOffTargetText; end,
+					get = function() return NameplateSCT.db.global.useOffTargetAppearance; end,
+					set = function(_, newValue) NameplateSCT.db.global.useOffTargetAppearance = newValue; end,
 					order = 100,
 					width = "full",
 				},
 				offTarget = {
 					type = 'group',
 					name = L["Off-Target Text Appearance"],
-					hidden = function() return not NameplateSCT.db.global.useOffTarget; end,
+					hidden = function() return not NameplateSCT.db.global.useOffTargetAppearance or not NameplateSCT.db.global.displayOffTargetText; end,
 					order = 101,
 					inline = true,
 					args = {


### PR DESCRIPTION
Nice addon. Hope I can be of some help.
Please let me know if this modification aligns with your coding style, and if there are any issues.
Thank you.

- Add a toggle to the options to enable or disable off-target text
- Add support for East Asian numeral formatting conventions to the number truncation feature
  1. Change the option type of 'Truncate Number' from toggle to select to specify the truncate method.
  2. Replace the block of truncation code with a separate function