### PR TITLE
Suggestion: melee miss/parry/dodge as non colored white text

### DIFF
--- a/NameplateSCT.lua
+++ b/NameplateSCT.lua
@@ -1134,7 +1134,9 @@ function NameplateSCT:MissEvent(guid, spellName, missType, spellId)
 	pow = true
 
 	text = MISS_EVENT_STRINGS[missType] or L["Missed"]
-	text = "|Cff"..color..text.."|r"
+	if spellName ~= nil then
+		text = "|Cff"..color..text.."|r"
+	end
 
 	self:DisplayText(guid, text, size, animation, spellId, pow, spellName)
 end


### PR DESCRIPTION
<img width="359" height="238" alt="image" src="https://github.com/user-attachments/assets/121d7f49-2978-4254-a12f-b67e46b970c7" />
